### PR TITLE
feat: construct call with response data

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Prettier check
+        run: npx prettier --check .

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 dist
 node_modules
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 node_modules
 package-lock.json
+mmr_store

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "printWidth": 80,
+  "trailingComma": "es5",
+  "useTabs": false,
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "arrowParens": "always",
+  "quoteProps": "consistent",
+  "bracketSpacing": true,
+  "endOfLine": "auto"
+}

--- a/README.md
+++ b/README.md
@@ -14,40 +14,40 @@ The Murmur Client depends on:
 You need to configure an `axios` and a `polkadot-js` instances to be injected in the Murmur Client.
 
 ```javascript
-import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
-import { KeyringPair } from "@polkadot/keyring/types";
-import axios from "axios";
-import { MurmurClient } from "murmur.js";
+import { ApiPromise, WsProvider, Keyring } from '@polkadot/api'
+import { KeyringPair } from '@polkadot/keyring/types'
+import axios from 'axios'
+import { MurmurClient } from 'murmur.js'
 
 /* Polkadot API initialization */
-const provider = new WsProvider("ws://127.0.0.1:9944");
-console.log("Provider initialized");
-const api = await ApiPromise.create({ provider });
-console.log("API initialized");
+const provider = new WsProvider('ws://127.0.0.1:9944')
+console.log('Provider initialized')
+const api = await ApiPromise.create({ provider })
+console.log('API initialized')
 
 /* Axios initialization */
 const httpClient = axios.create({
-  baseURL: "https://api.example.com",
+  baseURL: 'https://api.example.com',
   headers: {
-    "Content-Type": "application/json",
+    'Content-Type': 'application/json',
   },
-});
+})
 
 /* Define the master account (optional, it falls back to `alice`) */
-const keyring = new Keyring({ type: "sr25519" });
-const alice = keyring.addFromUri("//Alice");
+const keyring = new Keyring({ type: 'sr25519' })
+const alice = keyring.addFromUri('//Alice')
 
 /* MurmurClient initialization */
-const murmurClient = new MurmurClient(httpClient, api, alice);
-console.log("MurmurClient initialized");
+const murmurClient = new MurmurClient(httpClient, api, alice)
+console.log('MurmurClient initialized')
 
 // Use the MurmurClient instance to make requests
 murmurClient
-  .authenticate("username", "password")
+  .authenticate('username', 'password')
   .then((response) => {
-    console.log(response);
+    console.log(response)
   })
   .catch((error) => {
-    console.error(error);
-  });
+    console.error(error)
+  })
 ```

--- a/examples/create-execute/src/index.ts
+++ b/examples/create-execute/src/index.ts
@@ -1,40 +1,40 @@
-import { ApiPromise, WsProvider } from "@polkadot/api";
-import axios from "axios";
-import { MurmurClient } from "murmur.js";
+import { ApiPromise, WsProvider } from '@polkadot/api'
+import axios from 'axios'
+import { MurmurClient } from 'murmur.js'
 
 /* Polkadot API initialization */
-const provider = new WsProvider("ws://127.0.0.1:9944");
-console.log("Provider initialized");
-const api = await ApiPromise.create({ provider });
-console.log("API initialized");
+const provider = new WsProvider('ws://127.0.0.1:9944')
+console.log('Provider initialized')
+const api = await ApiPromise.create({ provider })
+console.log('API initialized')
 // Retrieve the chain & node information via rpc calls
 const [chain, nodeName, nodeVersion] = await Promise.all([
   api.rpc.system.chain(),
   api.rpc.system.name(),
   api.rpc.system.version(),
-]);
+])
 console.log(
   `You are connected to chain ${chain} using ${nodeName} v${nodeVersion}`
-);
+)
 
 /* Axios initialization */
 const httpClient = axios.create({
-  baseURL: "http://127.0.0.1:8000",
+  baseURL: 'http://127.0.0.1:8000',
   headers: {
-    "Content-Type": "application/json",
+    'Content-Type': 'application/json',
   },
-});
+})
 
 /* MurmurClient initialization */
-const murmurClient = new MurmurClient(httpClient, api);
-console.log("MurmurClient initialized");
+const murmurClient = new MurmurClient(httpClient, api)
+console.log('MurmurClient initialized')
 
-const loguinResult = await murmurClient.authenticate("admin", "password");
-console.log(loguinResult);
+const loguinResult = await murmurClient.authenticate('admin', 'password')
+console.log(loguinResult)
 
 await murmurClient.new(100, async (result: any) => {
-  console.log(`Tx Block Hash: ${result.status.asFinalized}`);
-  const bob = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
-  const call = api.tx.balances.transferAllowDeath(bob, 1000000000000);
-  await murmurClient.execute(call);
-});
+  console.log(`Tx Block Hash: ${result.status.asFinalized}`)
+  const bob = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty'
+  const call = api.tx.balances.transferAllowDeath(bob, 1000000000000)
+  await murmurClient.execute(call)
+})

--- a/examples/simple-connect/src/index.ts
+++ b/examples/simple-connect/src/index.ts
@@ -1,30 +1,30 @@
-import { ApiPromise, WsProvider } from "@polkadot/api";
-import axios from "axios";
-import { MurmurClient } from "murmur.js";
+import { ApiPromise, WsProvider } from '@polkadot/api'
+import axios from 'axios'
+import { MurmurClient } from 'murmur.js'
 
 /* Polkadot API initialization */
-const provider = new WsProvider("ws://127.0.0.1:9944");
-console.log("Provider initialized");
-const api = await ApiPromise.create({ provider });
-console.log("API initialized");
+const provider = new WsProvider('ws://127.0.0.1:9944')
+console.log('Provider initialized')
+const api = await ApiPromise.create({ provider })
+console.log('API initialized')
 // Retrieve the chain & node information via rpc calls
 const [chain, nodeName, nodeVersion] = await Promise.all([
   api.rpc.system.chain(),
   api.rpc.system.name(),
   api.rpc.system.version(),
-]);
+])
 console.log(
   `You are connected to chain ${chain} using ${nodeName} v${nodeVersion}`
-);
+)
 
 /* Axios initialization */
 const httpClient = axios.create({
-  baseURL: "https://api.example.com",
+  baseURL: 'https://api.example.com',
   headers: {
-    "Content-Type": "application/json",
+    'Content-Type': 'application/json',
   },
-});
+})
 
 /* MurmurClient initialization */
-new MurmurClient(httpClient, api);
-console.log("MurmurClient initialized");
+new MurmurClient(httpClient, api)
+console.log('MurmurClient initialized')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepare": "husky install"
   },
   "author": "Ideal Labs <hello@idealabs.network>",
   "dependencies": {
@@ -16,6 +17,20 @@
   },
   "devDependencies": {
     "@types/node": "^22.7.4",
+    "husky": "^8.0.0",
+    "lint-staged": "^15.2.10",
+    "prettier": "^3.3.3",
+    "prettier-plugin-organize-imports": "^4.1.0",
     "typescript": "^5.6.2"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,json,md}": [
+      "prettier --write"
+    ]
   }
 }

--- a/src/MurmurClient.ts
+++ b/src/MurmurClient.ts
@@ -13,7 +13,7 @@ export class MurmurClient {
   private http: AxiosInstance
   private idn: ApiPromise
   private masterAccount: KeyringPair
-  private finalizedBlockNumber: number
+  private finalizedBlockNumber: number | null
 
   /**
    * Creates an instance of MurmurClient.
@@ -29,9 +29,8 @@ export class MurmurClient {
     this.http = http
     this.idn = idn
     this.masterAccount = masterAccount ?? this.defaultMasterAccount()
-    this.finalizedBlockNumber = 0
+    this.finalizedBlockNumber = null
 
-    // Subscribe to the finalized heads (finalized blocks)
     const unsub = idn.rpc.chain.subscribeFinalizedHeads((header) => {
       this.finalizedBlockNumber = header.number.toNumber()
     })
@@ -86,6 +85,13 @@ export class MurmurClient {
         `The validity parameter must be within the range of 0 to ${MAX_U32}.`
       )
     }
+
+    if (!this.finalizedBlockNumber) {
+      throw new Error(
+        `No finalized blocks have been observed - are you sure the chain is running?`
+      )
+    }
+
     const request: NewRequest = {
       validity,
       current_block: this.finalizedBlockNumber,
@@ -119,16 +125,22 @@ export class MurmurClient {
    */
   async execute(
     call: Call,
-    callback: (result: any) => Promise<void> = async () => {}
+    callback: (result: any) => Promise<void> = async () => { }
   ): Promise<void> {
+
+    if (!this.finalizedBlockNumber) {
+      throw new Error(
+        `No finalized blocks have been observed - are you sure the chain is running?`
+      )
+    }
+
     const request: ExecuteRequest = {
       runtime_call: this.encodeCall(call),
       current_block: this.finalizedBlockNumber,
     }
     try {
-      const response = (await this.http.post('/execute', request))
-        .data as ExecuteResponse
-      const proxy_data = response.proxy_data
+      const response = (await this.http.post("/execute", request))
+        .data as ExecuteResponse;
 
       const outerCall = this.idn.tx.murmur.proxy(
         response.username,
@@ -162,7 +174,7 @@ export class MurmurClient {
 
   private async submitCall(
     call: Call,
-    callback: (result: any) => Promise<void> = async () => {}
+    callback: (result: any) => Promise<void> = async () => { }
   ): Promise<void> {
     const unsub = await call.signAndSend(this.masterAccount, (result: any) => {
       callback(result)

--- a/src/MurmurClient.ts
+++ b/src/MurmurClient.ts
@@ -125,9 +125,8 @@ export class MurmurClient {
    */
   async execute(
     call: Call,
-    callback: (result: any) => Promise<void> = async () => { }
+    callback: (result: any) => Promise<void> = async () => {}
   ): Promise<void> {
-
     if (!this.finalizedBlockNumber) {
       throw new Error(
         `No finalized blocks have been observed - are you sure the chain is running?`
@@ -139,8 +138,8 @@ export class MurmurClient {
       current_block: this.finalizedBlockNumber,
     }
     try {
-      const response = (await this.http.post("/execute", request))
-        .data as ExecuteResponse;
+      const response = (await this.http.post('/execute', request))
+        .data as ExecuteResponse
 
       const outerCall = this.idn.tx.murmur.proxy(
         response.username,
@@ -174,7 +173,7 @@ export class MurmurClient {
 
   private async submitCall(
     call: Call,
-    callback: (result: any) => Promise<void> = async () => { }
+    callback: (result: any) => Promise<void> = async () => {}
   ): Promise<void> {
     const unsub = await call.signAndSend(this.masterAccount, (result: any) => {
       callback(result)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./MurmurClient";
+export * from './MurmurClient'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,41 +1,41 @@
-import { SubmittableExtrinsic } from "@polkadot/api/types";
-import { ISubmittableResult } from "@polkadot/types/types";
+import { SubmittableExtrinsic } from '@polkadot/api/types'
+import { ISubmittableResult } from '@polkadot/types/types'
 
 export type NewRequest = {
-  validity: number;
-  current_block: number;
-  round_pubkey: string;
-};
+  validity: number
+  current_block: number
+  round_pubkey: string
+}
 
 export type ExecuteRequest = {
   // SCALE encoded runtime call
-  runtime_call: number[];
-  current_block: number;
-};
+  runtime_call: number[]
+  current_block: number
+}
 
 export type CreateData = {
-  root: number[];
-  size: bigint;
-  mmr_store: any;
-};
+  root: number[]
+  size: bigint
+  mmr_store: any
+}
 
 export type CreateResponse = {
-  username: string;
-  create_data: CreateData;
-};
+  username: string
+  create_data: CreateData
+}
 
 export type ProxyData = {
-  position: bigint;
+  position: bigint
   // The hash of the commitment
-  hash: number[];
-  ciphertext: number[];
-  proof_items: number[][];
-  size: bigint;
-};
+  hash: number[]
+  ciphertext: number[]
+  proof_items: number[][]
+  size: bigint
+}
 
 export type ExecuteResponse = {
-  username: string;
-  proxy_data: ProxyData;
-};
+  username: string
+  proxy_data: ProxyData
+}
 
-export type Call = SubmittableExtrinsic<"promise", ISubmittableResult>;
+export type Call = SubmittableExtrinsic<'promise', ISubmittableResult>

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,18 +13,29 @@ export type ExecuteRequest = {
   current_block: number;
 };
 
-export type Payload = {
-  pallet_name: string;
-  call_name: string;
-  call_data: any;
+export type CreateData = {
+  root: number[];
+  size: bigint;
+  mmr_store: any;
 };
 
 export type CreateResponse = {
-  payload: Payload;
+  username: string;
+  create_data: CreateData;
+};
+
+export type ProxyData = {
+  position: bigint;
+  // The hash of the commitment
+  hash: number[];
+  ciphertext: number[];
+  proof_items: number[][];
+  size: bigint;
 };
 
 export type ExecuteResponse = {
-  payload: Payload;
+  username: string;
+  proxy_data: ProxyData;
 };
 
-export type Extrinsic = SubmittableExtrinsic<"promise", ISubmittableResult>;
+export type Call = SubmittableExtrinsic<"promise", ISubmittableResult>;


### PR DESCRIPTION
closes https://github.com/ideal-lab5/murmur/issues/17

companion for https://github.com/ideal-lab5/murmur/pull/18

- remove the `constructExtrinsic` function that was prone to errors
- constructs the calls with the response data from the API