### PR TITLE
feat: add async finalized block number

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "author": "Ideal Labs <hello@idealabs.network>",
   "dependencies": {
     "@polkadot/api": "^13.2.1",
-    "axios": "^1.7.7",
-    "js-crypto-hkdf": "^1.0.7"
+    "axios": "^1.7.7"
   },
   "devDependencies": {
     "@types/node": "^22.7.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "author": "Ideal Labs <hello@idealabs.network>",
   "dependencies": {
     "@polkadot/api": "^13.2.1",
-    "axios": "^1.7.7"
+    "axios": "^1.7.7",
+    "js-crypto-hkdf": "^1.0.7"
   },
   "devDependencies": {
     "@types/node": "^22.7.4",

--- a/src/MurmurClient.ts
+++ b/src/MurmurClient.ts
@@ -8,6 +8,7 @@ import type {
   ExecuteResponse,
   CreateRequest,
 } from './types'
+import hkdf from 'js-crypto-hkdf'
 
 export class MurmurClient {
   private http: AxiosInstance
@@ -96,7 +97,6 @@ export class MurmurClient {
       validity,
       current_block: this.finalizedBlockNumber,
       round_pubkey: await this.getRoundPublic(),
-      ephem_msk: this.getEphemMsk(),
     }
 
     try {
@@ -190,10 +190,5 @@ export class MurmurClient {
 
   private encodeCall(ext: Call): number[] {
     return Array.from(ext.inner.toU8a())
-  }
-
-  private getEphemMsk(): number[] {
-    // TODO: Implement this function https://github.com/ideal-lab5/murmur/issues/13
-    return Array.from({ length: 32 }, () => Math.floor(Math.random() * 256))
   }
 }

--- a/src/MurmurClient.ts
+++ b/src/MurmurClient.ts
@@ -87,15 +87,9 @@ export class MurmurClient {
       )
     }
 
-    if (!this.finalizedBlockNumber) {
-      throw new Error(
-        `No finalized blocks have been observed - are you sure the chain is running?`
-      )
-    }
-
     const request: CreateRequest = {
       validity,
-      current_block: this.finalizedBlockNumber,
+      current_block: await this.getFinalizedBlockNumber(),
       round_pubkey: await this.getRoundPublic(),
     }
 
@@ -128,15 +122,9 @@ export class MurmurClient {
     call: Call,
     callback: (result: any) => Promise<void> = async () => {}
   ): Promise<void> {
-    if (!this.finalizedBlockNumber) {
-      throw new Error(
-        `No finalized blocks have been observed - are you sure the chain is running?`
-      )
-    }
-
     const request: ExecuteRequest = {
       runtime_call: this.encodeCall(call),
-      current_block: this.finalizedBlockNumber,
+      current_block: await this.getFinalizedBlockNumber(),
     }
     try {
       const response = (await this.http.post('/execute', request))
@@ -191,4 +179,25 @@ export class MurmurClient {
   private encodeCall(ext: Call): number[] {
     return Array.from(ext.inner.toU8a())
   }
+<<<<<<< HEAD
+=======
+
+  private getEphemMsk(): number[] {
+    // TODO: Implement this function https://github.com/ideal-lab5/murmur/issues/13
+    return Array.from({ length: 32 }, () => Math.floor(Math.random() * 256))
+  }
+
+  private async getFinalizedBlockNumber(): Promise<number> {
+    return new Promise((resolve) => {
+      const checkFinalizedBlockNumber = () => {
+        if (this.finalizedBlockNumber !== null) {
+          resolve(this.finalizedBlockNumber)
+        } else {
+          setTimeout(checkFinalizedBlockNumber, 100) // Check again after 100ms
+        }
+      }
+      checkFinalizedBlockNumber()
+    })
+  }
+>>>>>>> fed3759 (feat: add async finalized block number)
 }

--- a/src/MurmurClient.ts
+++ b/src/MurmurClient.ts
@@ -6,7 +6,7 @@ import type {
   CreateResponse,
   ExecuteRequest,
   ExecuteResponse,
-  NewRequest,
+  CreateRequest,
 } from './types'
 
 export class MurmurClient {
@@ -92,10 +92,11 @@ export class MurmurClient {
       )
     }
 
-    const request: NewRequest = {
+    const request: CreateRequest = {
       validity,
       current_block: this.finalizedBlockNumber,
-      round_pubkey: (await this.getRoundPublic()).toString(),
+      round_pubkey: await this.getRoundPublic(),
+      ephem_msk: this.getEphemMsk(),
     }
 
     try {
@@ -159,7 +160,7 @@ export class MurmurClient {
     }
   }
 
-  private async getRoundPublic(): Promise<String> {
+  private async getRoundPublic(): Promise<string> {
     await this.idn.isReady
     let roundPublic = await this.idn.query.etf.roundPublic()
     return roundPublic.toString()
@@ -189,5 +190,10 @@ export class MurmurClient {
 
   private encodeCall(ext: Call): number[] {
     return Array.from(ext.inner.toU8a())
+  }
+
+  private getEphemMsk(): number[] {
+    // TODO: Implement this function https://github.com/ideal-lab5/murmur/issues/13
+    return Array.from({ length: 32 }, () => Math.floor(Math.random() * 256))
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,11 @@
 import { SubmittableExtrinsic } from '@polkadot/api/types'
 import { ISubmittableResult } from '@polkadot/types/types'
 
-export type NewRequest = {
+export type CreateRequest = {
   validity: number
   current_block: number
   round_pubkey: string
+  ephem_msk: number[]
 }
 
 export type ExecuteRequest = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ export type CreateRequest = {
   validity: number
   current_block: number
   round_pubkey: string
-  ephem_msk: number[]
 }
 
 export type ExecuteRequest = {


### PR DESCRIPTION
Gets `finalizedBlockNumber` via an async function instead of checking its existence before calling it